### PR TITLE
fix broken image link

### DIFF
--- a/main-kata/presentation/reladomoKata/ReladomoKata.xml
+++ b/main-kata/presentation/reladomoKata/ReladomoKata.xml
@@ -14,6 +14,7 @@
   specific language governing permissions and limitations
   under the License.
   -->
+<!-- Portions copyright Yu Matsubayashi. Licensed under Apache 2.0 license -->
 
 <dbs:slides xmlns="http://docbook.org/ns/docbook"
     xmlns:dbs="http://docbook.org/ns/docbook-slides">
@@ -173,7 +174,7 @@
             </itemizedlist>
             <para>Person.xml</para>
             <imageobject>
-                <imagedata fileref="PersonXML.png" align="center" format="png" />
+                <imagedata fileref="PersonXml.png" align="center" format="png" />
             </imageobject>
         </dbs:foil>
         <dbs:foil>


### PR DESCRIPTION
current ( https://goldmansachs.github.io/reladomo-kata/main-kata-presentation/ReladomoKata.xhtml#(8) )

![image](https://cloud.githubusercontent.com/assets/1635885/24048845/7f0647e0-0b6d-11e7-8087-895645fc2de1.png)

I fixed filename from `PersonXml.png` to `PersonXML.png`.