### PR TITLE
Fix typo in audit-only and bitemporal docs

### DIFF
--- a/reladomo-tour/tour-doc/src/docbook/auditonly-api.xml
+++ b/reladomo-tour/tour-doc/src/docbook/auditonly-api.xml
@@ -180,7 +180,7 @@ public void run() throws Exception
     MithraManagerProvider.getMithraManager().executeTransactionalCommand(tx -> {
 
         // Simulate the db change happening on a specific date - Do not do this in production
-        setProcessingTime(date, tx);
+        doNotDoThisInProduction(date, tx);
 
         Customer customer = new Customer();
         customer.setFirstName("mickey");
@@ -244,7 +244,7 @@ public void run() throws Exception
     MithraManagerProvider.getMithraManager().executeTransactionalCommand(tx ->
     {
         // Simulate the db change happening on a specific date - Do not do this in production
-        setProcessingTime(date, tx);
+        doNotDoThisInProduction(date, tx);
 
         Operation id = CustomerAccountFinder.accountId().eq(accountId);
         CustomerAccount account = CustomerAccountFinder.findOne(id);
@@ -333,7 +333,7 @@ insert into CUSTOMER_ACCOUNT(ACCOUNT_ID,CUSTOMER_ID,ACCOUNT_NAME,ACCOUNT_TYPE,BA
     MithraManagerProvider.getMithraManager().executeTransactionalCommand(tx ->
     {
         // Simulate the db change happening on a specific date - Do not do this in production
-        setProcessingTime(date, tx);
+        doNotDoThisInProduction(date, tx);
 
         Operation id = CustomerAccountFinder.accountId().eq(accountId);
         CustomerAccount account = CustomerAccountFinder.findOne(id);

--- a/reladomo-tour/tour-doc/src/docbook/bitemporal-api.xml
+++ b/reladomo-tour/tour-doc/src/docbook/bitemporal-api.xml
@@ -206,7 +206,7 @@ public void run() throws Exception
     MithraManagerProvider.getMithraManager().executeTransactionalCommand(tx ->
     {
         // Simulate the db change happening on a specific date - Do not do this in production
-        setProcessingTime(date, tx);
+        doNotDoThisInProduction(date, tx);
 
         Customer customer = new Customer(jan1);
         customer.setFirstName("mickey");
@@ -277,7 +277,7 @@ public void run() throws Exception
         Timestamp timestamp = DateUtils.parse(date);
 
         // Simulate the db change happening on a specific date - Do not do this in production
-        setProcessingTime(date, tx);
+        doNotDoThisInProduction(date, tx);
 
         Operation ts = CustomerAccountFinder.businessDate().eq(timestamp);
         Operation id = CustomerAccountFinder.accountId().eq(accountId);
@@ -375,7 +375,7 @@ where t0.ACCOUNT_ID = 100]]>
     MithraManagerProvider.getMithraManager().executeTransactionalCommand(tx -> {
 
         // Simulate the db change happening on a specific date - Do not do this in production
-        setProcessingTime(processingDate, tx);
+        doNotDoThisInProduction(processingDate, tx);
 
         Timestamp businessDateTs = DateUtils.parse(businessDate);
         Operation ts = CustomerAccountFinder.businessDate().eq(businessDateTs);


### PR DESCRIPTION
Pull request #21 renamed the method setProcessingTime to
doNotDoThisInProduction in the example code but not the
docbook XMLs. This commit fixes the docbook XMLs.